### PR TITLE
OT127-69/Feat/Crear-metodo-devuelve-encabezado-seguridad

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -15,9 +15,7 @@ const Get = () => {
 
 const getSecureHeader = () => {
   const token = localStorage.getItem("token");
-  token? {Authorization: "Bearer " + token} : {error:'No token found'}
+  token ? { Authorization: "Bearer " + token } : { error: "No token found" };
 };
 
 export default Get;
-
-/* Criterios de aceptacion: Generar un metodo en el servicio de peticiones HTTP privadas, que verifique la existencia del token en el localStorage y que devuelva un objeto Header Authorization con el valor "Bearer " + el token obtenido. */

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,15 +1,23 @@
-import axios from 'axios';
+import axios from "axios";
 
 const config = {
-    headers: {
-        Group: 01                //Aqui va el ID del equipo!!
-    }
-}
+  headers: {
+    Group: 01, //Aqui va el ID del equipo!!
+  },
+};
 
 const Get = () => {
-    axios.get('https://jsonplaceholder.typicode.com/users', config)
-    .then(res => console.log(res))
-    .catch(err => console.log(err))
-}
+  axios
+    .get("https://jsonplaceholder.typicode.com/users", config)
+    .then((res) => console.log(res))
+    .catch((err) => console.log(err));
+};
 
-export default Get
+const getSecureHeader = () => {
+  const token = localStorage.getItem("token");
+  token? {Authorization: "Bearer " + token} : {error:'No token found'}
+};
+
+export default Get;
+
+/* Criterios de aceptacion: Generar un metodo en el servicio de peticiones HTTP privadas, que verifique la existencia del token en el localStorage y que devuelva un objeto Header Authorization con el valor "Bearer " + el token obtenido. */


### PR DESCRIPTION
COMO: Desarrollador
QUIERO: Configurar el header de las peticiones HTTP
PARA: Estandarizar la seguridad de las mismas

Criterios de aceptacion: Generar un metodo en el servicio de peticiones HTTP privadas, que verifique la existencia del token en el localStorage y que devuelva un objeto Header Authorization con el valor "Bearer " + el token obtenido.