### PR TITLE
OT127-74 feat metodo Get rutas publicas

### DIFF
--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -1,15 +1,23 @@
-import axios from 'axios';
+import axios from "axios";
 
 const config = {
-    headers: {
-        Group: 01                //Aqui va el ID del equipo!!
-    }
-}
+  headers: {
+    Group: 127, //Aqui va el ID del equipo!!
+  },
+};
 
-const Get = () => {
-    axios.get('https://jsonplaceholder.typicode.com/users', config)
-    .then(res => console.log(res))
-    .catch(err => console.log(err))
-}
+const Get = async (url, id) => {
+  if (id) {
+    const response = await axios
+      .get(`${url}/${id}`, config)
+      .catch((err) => err.message);
 
-export default Get
+    return response;
+  } else {
+    const response = await axios.get(url, config).catch((err) => err.message);
+
+    return response;
+  }
+};
+
+export { Get };


### PR DESCRIPTION
Descripción
COMO: Desarrollador
QUIERO: Hacer peticiones GET a la API de forma centralizada
PARA: Estandarizar la logica de la comunicación con el servidor.

Criterios de aceptacion: En el servicio publicApiService.js y agregar un metodo que reciba una ruta destino, un id (que puede ser null) el cual debera ser concatenado al final de la url luego de una / y realice una petición GET a la API.