### PR TITLE
OT127-72/feat/patch-request-to-private-API-endpoints

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const config = {
   headers: {
-    Group: 01, //Aqui va el ID del equipo!!
+    Group: 127,
   },
 };
 
@@ -15,7 +15,26 @@ const Get = () => {
 
 const getSecureHeader = () => {
   const token = localStorage.getItem("token");
-  token ? { Authorization: "Bearer " + token } : { error: "No token found" };
+  return token
+    ? { Authorization: "Bearer " + token }
+    : { error: "No token found" };
+};
+
+export const privateServicePatch = (route, id, data) => {
+  let url = id ? `${route}/${id}` : route;
+  let token = getSecureHeader();
+  const { Authorization, error } = token;
+
+  if (Authorization) {
+    axios.patch(url, data, {
+      header: {
+        ...config.headers,
+        Authorization,
+      },
+    }); // TODO: Controlar errores
+  } else {
+    return error;
+  }
 };
 
 export default Get;

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,16 +1,16 @@
 import axios from "axios";
 
 const config = {
-	headers: {
-		Group: "127", 
-	},
+  headers: {
+    Group: "127",
+  },
 };
 
 export const Get = () => {
-	axios
-		.get("https://jsonplaceholder.typicode.com/users", config)
-		.then((res) => console.log(res))
-		.catch((err) => console.log(err));
+  axios
+    .get("https://jsonplaceholder.typicode.com/users", config)
+    .then((res) => console.log(res))
+    .catch((err) => console.log(err));
 };
 
 export const getSecureHeader = () => {
@@ -33,18 +33,18 @@ export const privateServicePatch = (route, id, data) => {
       },
     }); // TODO: Controlar errores
   }
-      
-export const Put = () => {
-	axios
-		.put(url, data, config)
-		.then((res) => {
-			return res
-		})
-		.catch((err) => {
-			return err
-		});
-}
+};
 
+export const Put = (url, data) => {
+  axios
+    .put(url, data, config)
+    .then((res) => {
+      return res;
+    })
+    .catch((err) => {
+      return err;
+    });
+};
 
 export const getPrivate = async (route, id = null) => {
   try {

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,16 +1,9 @@
 import axios from "axios";
 
-<<<<<<< HEAD
-let config = {
-  headers: {
-    Group: 127,
-  },
-=======
 const config = {
 	headers: {
 		Group: "127", 
 	},
->>>>>>> 1ca2a9788b17199aa7ae5f3ddb9cc1887c198a01
 };
 
 export const Get = () => {
@@ -27,7 +20,6 @@ export const getSecureHeader = () => {
     : { error: "No token found" };
 };
 
-<<<<<<< HEAD
 export const privateServicePatch = (route, id, data) => {
   let url = id ? `${route}/${id}` : route;
   let token = getSecureHeader();
@@ -40,10 +32,8 @@ export const privateServicePatch = (route, id, data) => {
         Authorization,
       },
     }); // TODO: Controlar errores
-  } else {
+  }
       
-const getPrivate = async (route, id = null) => {
-=======
 export const Put = () => {
 	axios
 		.put(url, data, config)
@@ -57,7 +47,6 @@ export const Put = () => {
 
 
 export const getPrivate = async (route, id = null) => {
->>>>>>> 1ca2a9788b17199aa7ae5f3ddb9cc1887c198a01
   try {
     let url;
     id ? (url = route + "/" + id) : (url = route);
@@ -78,5 +67,3 @@ export const getPrivate = async (route, id = null) => {
     return error;
   }
 };
-
-


### PR DESCRIPTION
Crear método reutilizable que realice una petición PATCH a los endpoints privados de la API:
Criterios de aceptacion: El método deberá recibir una ruta destino, un identificador y un objeto con la estructura de datos para enviar en el BODY. Deberá invocar el método para agregar el encabezado Authorization en base al token del usuario y realizar una petición PATCH. Agregarlo en privateApiService.js.

Summary

- Creacion de la funcion privateServicePatch.

Evidence:
![funcion](https://user-images.githubusercontent.com/65054792/151569521-7dcc6789-186c-48f2-9054-6bd37231b2e8.png)

![ejemplo](https://user-images.githubusercontent.com/65054792/151569540-c1ff085b-0252-4c88-a488-c2cc0c532512.png)
