### PR TITLE
OT127-79/Feat/extender-servicio-HTTP-para-las-peticiones-de-Categorias

### DIFF
--- a/src/Services/categoriesService.js
+++ b/src/Services/categoriesService.js
@@ -1,0 +1,34 @@
+import Axios from "axios";
+
+const url = `http://ongapi.alkemy.org/api/categories`;
+
+export const getCategory = async (formValues, setFormValues, id) => {
+	try {
+		const {data} = await Axios.get(url + "/" + id);
+		const {name, description, image} = data.data;
+		setFormValues({
+			...formValues,
+			name: name,
+			description: description,
+			image: image,
+		});
+	} catch (error) {
+		return error;
+	}
+};
+
+export const puttCategory = (id, name, description, image) => {
+	try {
+		Axios.put(url + "/" + id, {id, name, description, image});
+	} catch (error) {
+		return error;
+	}
+};
+
+export const posCategory = (name, description, image) => {
+	try {
+		Axios.post(url, {name, description, image});
+	} catch (error) {
+		return error;
+	}
+};

--- a/src/Services/categoriesService.js
+++ b/src/Services/categoriesService.js
@@ -2,30 +2,24 @@ import Axios from "axios";
 
 const url = `http://ongapi.alkemy.org/api/categories`;
 
-export const getCategory = async (formValues, setFormValues, id) => {
+export const getCategory = async (id) => {
 	try {
 		const {data} = await Axios.get(url + "/" + id);
-		const {name, description, image} = data.data;
-		setFormValues({
-			...formValues,
-			name: name,
-			description: description,
-			image: image,
-		});
+		return data;
 	} catch (error) {
 		return error;
 	}
 };
 
-export const puttCategory = (id, name, description, image) => {
+export const putCategory = (id, name, description, image) => {
 	try {
-		Axios.put(url + "/" + id, {id, name, description, image});
+		Axios.put(url + "/" + id, {name, description, image});
 	} catch (error) {
 		return error;
 	}
 };
 
-export const posCategory = (name, description, image) => {
+export const postCategory = (name, description, image) => {
 	try {
 		Axios.post(url, {name, description, image});
 	} catch (error) {


### PR DESCRIPTION
Fla 

Este es el PR de los servicios HTTP de categorías, cree todos los servicios según hice las peticiones en el componente  
![Captura de pantalla 2022-01-31 225031](https://user-images.githubusercontent.com/63797901/151901714-80107e24-7be9-40c3-aa11-6282dfd9003d.png)

