### PR TITLE
Ot127 102/feat/show-errors-when-a-requests-fail

### DIFF
--- a/src/Components/Activities/Activities.js
+++ b/src/Components/Activities/Activities.js
@@ -1,11 +1,8 @@
 import React from "react";
 
-const Activity = ({ message }) => {
-    return(
-        <div 
-            className='textHTML'
-            dangerouslySetInnerHTML={{ __html: message }} 
-        />
-    )
-}
+const Activities = ({ message }) => {
+  return (
+    <div className="textHTML" dangerouslySetInnerHTML={{ __html: message }} />
+  );
+};
 export default Activities;

--- a/src/Components/News/NewsForm.js
+++ b/src/Components/News/NewsForm.js
@@ -6,36 +6,37 @@ import { CKEditor } from "@ckeditor/ckeditor5-react";
 import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
 import "@ckeditor/ckeditor5-build-classic/build/translations/es";
 import axios from "axios";
+import { sweetAlertError } from "../../Services/sweetAlertServices";
 import "../FormStyles.css";
 
 const NewsForm = () => {
   const [initialValues, setInitialValues] = useState({
     name: "",
     contenido: "",
-    categorie:"",
+    categorie: "",
     image: "",
   });
-  const [ordersList, setOrdersList] = useState([]); 
+  const [ordersList, setOrdersList] = useState([]);
   const [loading, setLoading] = useState(false);
   const [dataCategorie, setDataCategorie] = useState([]);
 
   const { id } = useParams();
   const url = "http://ongapi.alkemy.org/api/news";
-  const urlCategories = 'http://ongapi.alkemy.org/api/categories';
+  const urlCategories = "http://ongapi.alkemy.org/api/categories";
 
   const getCategorieData = () => {
     if (id) {
-          axios.get(urlCategories)
-              .then((response) => {
-                  const dataCategorie = response.data.data;
-                  setDataCategorie(dataCategorie);
-              })
-              .catch((error) => {
-                  return error;
-          });
-
-      } 
-  }
+      axios
+        .get(urlCategories)
+        .then((response) => {
+          const dataCategorie = response.data.data;
+          setDataCategorie(dataCategorie);
+        })
+        .catch((error) => {
+          return error;
+        });
+    }
+  };
 
   const getOrdersList = async () => {
     await axios
@@ -83,7 +84,7 @@ const NewsForm = () => {
     }
     getOrdersList();
     getCategorieData();
-  }, []); 
+  }, []);
 
   const toBase64 = (file) => {
     return new Promise((resolve) => {
@@ -106,20 +107,15 @@ const NewsForm = () => {
     }
 
     if (id) {
-      await axios
-      .put(`${url}/${id}`, formValues)
-      .catch((err) => {
-        alert(err.message);
+      await axios.put(`${url}/${id}`, formValues).catch((err) => {
+        sweetAlertError("No se pudo actualizar esta novedad.");
       });
     } else {
-      await axios
-      .post(url, formValues)
-      .catch((err) => {
-        alert(err.message);
+      await axios.post(url, formValues).catch((err) => {
+        sweetAlertError("No se pudo crear esta novedad.");
       });
     }
   };
-
 
   const inputFileRef = useRef();
 
@@ -171,7 +167,7 @@ const NewsForm = () => {
                 placeholder="titulo"
               />
               <ErrorMessage name="name" render={(msg) => <div>{msg}</div>} />
-              
+
               <label htmlFor="contenido">Contenido</label>
               <Field name="contenido">
                 {({ field }) => (
@@ -194,16 +190,21 @@ const NewsForm = () => {
                 render={(msg) => <div>{msg}</div>}
               />
 
-              <label htmlFor="categorie">Categorias</label> 
-                <Field component="select" as='select' name="categorie" type="categorie">
-                    {dataCategorie.map(element => {
-                        return (
-                            <option key={element.id} value={element.id}>
-                                {element.name}
-                            </option>
-                        )
-                    })}
-                </Field>
+              <label htmlFor="categorie">Categorias</label>
+              <Field
+                component="select"
+                as="select"
+                name="categorie"
+                type="categorie"
+              >
+                {dataCategorie.map((element) => {
+                  return (
+                    <option key={element.id} value={element.id}>
+                      {element.name}
+                    </option>
+                  );
+                })}
+              </Field>
               <ErrorMessage name="categorie" />
 
               <label htmlFor="categorie">Cargar Imagen</label>

--- a/src/Services/newsService.js
+++ b/src/Services/newsService.js
@@ -1,11 +1,14 @@
 import { Get } from "./publicApiService";
+import { sweetAlertError } from "./sweetAlertServices";
 
 const url = "http://ongapi.alkemy.org/api/news";
 
 const getNews = async (setMethod) => {
-  let newsFromAPI = await Get(url, null);
-  let data = newsFromAPI.data.data;
-  setMethod(data);
+  try {
+    let newsFromAPI = await Get(url, null);
+    let data = newsFromAPI.data.data;
+    setMethod(data);
+  } catch (error) {}
 };
 
 export default getNews;

--- a/src/Services/newsService.js
+++ b/src/Services/newsService.js
@@ -8,7 +8,13 @@ const getNews = async (setMethod) => {
     let newsFromAPI = await Get(url, null);
     let data = newsFromAPI.data.data;
     setMethod(data);
-  } catch (error) {}
+  } catch (error) {
+    if (error.response.status === 500) {
+      sweetAlertError("Ha ocurrido un problema en el servidor!");
+    } else {
+      sweetAlertError("Ha ocurrido un problema!");
+    }
+  }
 };
 
 export default getNews;


### PR DESCRIPTION
Utilizando los componentes reutilizables de alerta, mostrar un error al usuario cuando las peticiones realizadas desde el servicio tengan un error.


Summary

- Implementacion de alertas con SweetAlert2 en newsService.

Evidence
![sweet](https://user-images.githubusercontent.com/65054792/152624954-d6d264e1-c07d-491f-99dd-2e91a0d2bf0e.png)


