### PR TITLE
Ot127 112/feat/reducer de miembros

### DIFF
--- a/src/Components/Activities/Activities.js
+++ b/src/Components/Activities/Activities.js
@@ -1,11 +1,8 @@
 import React from "react";
 
-const Activity = ({ message }) => {
-    return(
-        <div 
-            className='textHTML'
-            dangerouslySetInnerHTML={{ __html: message }} 
-        />
-    )
-}
+const Activities = ({ message }) => {
+  return (
+    <div className="textHTML" dangerouslySetInnerHTML={{ __html: message }} />
+  );
+};
 export default Activities;

--- a/src/Components/Members/MemberListUs.js
+++ b/src/Components/Members/MemberListUs.js
@@ -1,18 +1,26 @@
-import { useEffect } from "react";
-
+import { useState, useEffect } from "react";
+import axios from "axios";
 import "./styles.scss";
 
-//redux
-import { useDispatch, useSelector } from "react-redux";
-import { fetchMembers } from "../../Redux/reducers/membersSlice";
-
 const MemberListUs = () => {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(fetchMembers());
-  }, []); //eslint-disable-line
+  const url = "http://ongapi.alkemy.org/api/members";
+  const [members, setMembers] = useState([]);
+  const [loading, setLoading] = useState(true);
 
-  const { members, loading } = useSelector((state) => state.membersReducer);
+  const getMembers = async () => {
+    await axios
+      .get(url)
+      .then((res) => {
+        setMembers(res.data.data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        alert(err);
+      });
+  };
+  useEffect(() => {
+    getMembers();
+  }, []);
 
   return (
     <>

--- a/src/Components/Members/MemberListUs.js
+++ b/src/Components/Members/MemberListUs.js
@@ -1,55 +1,49 @@
-import { useState, useEffect } from "react"
-import axios from "axios"
-import "./styles.scss"
+import { useEffect } from "react";
 
+import "./styles.scss";
+
+//redux
+import { useDispatch, useSelector } from "react-redux";
+import { fetchMembers } from "../../Redux/reducers/membersSlice";
 
 const MemberListUs = () => {
-	const url = "http://ongapi.alkemy.org/api/members"
-	const [ members, setMembers ] = useState([])
-	const [ loading, setLoading ] = useState(true)
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchMembers());
+  }, []); //eslint-disable-line
 
-	const getMembers = async () => {
-		await	axios.get(url)
-			.then(res => {
-				setMembers(res.data.data)
-				setLoading(false)
-			})
-			.catch(err => {
-				alert(err)
-			})
-	}
-	useEffect(() => {
-	getMembers()
-	}, [])
+  const { members, loading } = useSelector((state) => state.membersReducer);
 
-	return (
-		<>
-			{(loading)
-				? <h1>Cargando...</h1>
-				: <div className="members">
-					<h1>Miembros</h1>
-					<div className="members__container">
-						{members.map(member => (
-							<li className="members__item" key={member.id}>
-								<div className="members__item__img">
-									<img src={member.image} alt={member.name} />
-								</div>
-								<div className="members__item__body">
-									<div>
-										<h2>{member.name}</h2>
-										<p>{member.description}</p>
-									</div>
-									<div>
-										<p>{member.facebookUrl}</p>
-										<p>{member.linkedinUrl}</p>
-									</div>
-								</div>
-							</li>
-						))}
-					</div>
-				</div>}
-		</>
-	)
-}
+  return (
+    <>
+      {loading ? (
+        <h1>Cargando...</h1>
+      ) : (
+        <div className="members">
+          <h1>Miembros</h1>
+          <div className="members__container">
+            {members.map((member) => (
+              <li className="members__item" key={member.id}>
+                <div className="members__item__img">
+                  <img src={member.image} alt={member.name} />
+                </div>
+                <div className="members__item__body">
+                  <div>
+                    <h2>{member.name}</h2>
+                    <p>{member.description}</p>
+                  </div>
+                  <div>
+                    <p>{member.facebookUrl}</p>
+                    <p>{member.linkedinUrl}</p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
 
-export default MemberListUs
+export default MemberListUs;

--- a/src/Components/Members/MembersList.js
+++ b/src/Components/Members/MembersList.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
-import { getMembers } from "../../Services/membersService";
 
+// Material UI
 import {
   Container,
   Table,
@@ -15,6 +15,7 @@ import { styled } from "@mui/material/styles";
 import TableCell, { tableCellClasses } from "@mui/material/TableCell";
 import TableRow, { tableRowClasses } from "@mui/material/TableRow";
 
+//redux
 import { useDispatch, useSelector } from "react-redux";
 import { fetchMembers } from "../../Redux/reducers/membersSlice";
 
@@ -24,7 +25,7 @@ const MembersList = () => {
     dispatch(fetchMembers());
   }, []); //eslint-disable-line
 
-  const { list } = useSelector((state) => state.membersReducer);
+  const { members } = useSelector((state) => state.membersReducer);
 
   const handleEdit = (id) => {
     // Logica a desarrollar
@@ -72,7 +73,7 @@ const MembersList = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {list.map((member) => (
+            {members.map((member) => (
               <StyledTableRow key={member.id}>
                 <StyledTableCell scope="row">{member.name}</StyledTableCell>
                 <StyledTableCell>

--- a/src/Components/Members/MembersList.js
+++ b/src/Components/Members/MembersList.js
@@ -15,17 +15,16 @@ import { styled } from "@mui/material/styles";
 import TableCell, { tableCellClasses } from "@mui/material/TableCell";
 import TableRow, { tableRowClasses } from "@mui/material/TableRow";
 
+import { useDispatch, useSelector } from "react-redux";
+import { fetchMembers } from "../../Redux/reducers/membersSlice";
+
 const MembersList = () => {
-  const [membersList, setMembersList] = useState([]);
-
-  const getMembersList = async () => {
-    const res = await getMembers();
-    setMembersList(res.data.data);
-  };
-
+  const dispatch = useDispatch();
   useEffect(() => {
-    getMembersList();
-  }, []);
+    dispatch(fetchMembers());
+  }, []); //eslint-disable-line
+
+  const { list } = useSelector((state) => state.membersReducer);
 
   const handleEdit = (id) => {
     // Logica a desarrollar
@@ -73,7 +72,7 @@ const MembersList = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {membersList.map((member) => (
+            {list.map((member) => (
               <StyledTableRow key={member.id}>
                 <StyledTableCell scope="row">{member.name}</StyledTableCell>
                 <StyledTableCell>

--- a/src/Redux/reducers/membersSlice.js
+++ b/src/Redux/reducers/membersSlice.js
@@ -1,0 +1,39 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { getMembers } from "../../Services/membersService";
+
+export const fetchMembers = createAsyncThunk(
+  "members/fetchMembers",
+  async () => {
+    const response = await getMembers();
+    return response.data.data;
+  }
+);
+
+const membersSlice = createSlice({
+  name: "members",
+  initialState: {
+    list: [],
+    loading: false,
+    status: null,
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchMembers.pending, (state, action) => {
+        state.loading = true;
+      })
+      .addCase(fetchMembers.fulfilled, (state, action) => {
+        state.loading = false;
+        state.status = "success";
+        // agrega todos los miembros obtenidos al array
+        state.list = action.payload;
+      })
+      .addCase(fetchMembers.rejected, (state, action) => {
+        state.loading = false;
+        state.status = "failed";
+        state.error = action.error.message;
+      });
+  },
+});
+
+export default membersSlice.reducer;

--- a/src/Redux/reducers/membersSlice.js
+++ b/src/Redux/reducers/membersSlice.js
@@ -1,6 +1,12 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { getMembers } from "../../Services/membersService";
 
+const initialState = {
+  members: [],
+  loading: false,
+  status: null,
+};
+
 export const fetchMembers = createAsyncThunk(
   "members/fetchMembers",
   async () => {
@@ -11,11 +17,7 @@ export const fetchMembers = createAsyncThunk(
 
 const membersSlice = createSlice({
   name: "members",
-  initialState: {
-    list: [],
-    loading: false,
-    status: null,
-  },
+  initialState: initialState,
   reducers: {},
   extraReducers: (builder) => {
     builder
@@ -26,7 +28,7 @@ const membersSlice = createSlice({
         state.loading = false;
         state.status = "success";
         // agrega todos los miembros obtenidos al array
-        state.list = action.payload;
+        state.members = action.payload;
       })
       .addCase(fetchMembers.rejected, (state, action) => {
         state.loading = false;

--- a/src/Redux/store/store.js
+++ b/src/Redux/store/store.js
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
-import {authReducer} from "../reducers/authReducer";
-import newsReducer from "../reducers/newsSlice"
+import { authReducer } from "../reducers/authReducer";
+import membersReducer from "../reducers/membersSlice";
+import newsReducer from "../reducers/newsSlice";
 
 export default configureStore({
   reducer: {
     authReducer: authReducer,
-    newsReducer: newsReducer
+    newsReducer: newsReducer,
+    membersReducer: membersReducer,
   },
 });


### PR DESCRIPTION
Resumen

- Desarrollar un reducer para gestionar el estado de los Miembros.
- El mismo deberá tener una acción para renderizar el listado de los Miembros en BackOffice.
- Utilizar el método createAsyncThunk de Redux Toolkit para la creación de thunks


Evidencia

Reducer miembros gestiona el estado de miembros en BackOffice:


![evidencia miembros backoffice](https://user-images.githubusercontent.com/70604758/152648105-c5e74372-07aa-4869-9f10-2a43649e97eb.png)

Utilizar el método createAsyncThunk:

![createAsycnThunk](https://user-images.githubusercontent.com/70604758/152648138-61975b81-3baf-491a-9fda-daf49d67b023.png)

