### PR TITLE
Ot127-110/feat/create-slides-reducer

### DIFF
--- a/src/Components/Activities/Activities.js
+++ b/src/Components/Activities/Activities.js
@@ -1,11 +1,8 @@
 import React from "react";
 
-const Activity = ({ message }) => {
-    return(
-        <div 
-            className='textHTML'
-            dangerouslySetInnerHTML={{ __html: message }} 
-        />
-    )
-}
+const Activities = ({ message }) => {
+  return (
+    <div className="textHTML" dangerouslySetInnerHTML={{ __html: message }} />
+  );
+};
 export default Activities;

--- a/src/Components/Slides/SliderHome.js
+++ b/src/Components/Slides/SliderHome.js
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from "react";
-import "./SliderHome.scss";
 import { getSlides } from "../../Redux/reducers/slidesSlice";
 import { useSelector, useDispatch } from "react-redux";
+import "./SliderHome.scss";
 
 const SliderHome = () => {
   const carousel = useRef(null);

--- a/src/Components/Slides/SliderHome.js
+++ b/src/Components/Slides/SliderHome.js
@@ -1,112 +1,111 @@
-import React, { useRef, useEffect } from 'react';
-import './SliderHome.scss'
-import { getSlidesData } from '../../Services/slidesApiService';
+import React, { useRef, useEffect } from "react";
+import "./SliderHome.scss";
+import { getSlides } from "../../Redux/reducers/slidesSlice";
+import { useSelector, useDispatch } from "react-redux";
 
 const SliderHome = () => {
-    const carousel = useRef(null)
-    const intervalCarousel = useRef(null)
+  const carousel = useRef(null);
+  const intervalCarousel = useRef(null);
 
-    const [sliderData, setSliderData] = React.useState([])
+  const dispatch = useDispatch();
 
-    const nextSlide = () => {
-        // Me aseguro que se ejecute solo cuando el carrusel tenga contenido
-        if (carousel.current.children.length > 0) {
-            // Primer item carrusel
-            const firstItem = carousel.current.children[0]
-            // Animacion de transicion
-            carousel.current.style.transition = '300ms ease-out all'
-            // obtengo cuanto mide cada item, asi se cuanto desplazarlo
-            const slideWidth = firstItem.offsetWidth
-            // Movemos el slide actual para mostrar el nuevo
-            carousel.current.style.transform = `translateX(-${slideWidth}px)`
+  useEffect(() => {
+    dispatch(getSlides());
+  }, []);
 
-            // el slide viejo lo tenemos que poner al final de la fila, asi se comporta como slide infinito
-            // pero antes de ponerlo al final, hay que esperar que termine la animacion
-            setTimeout(() => {
-                carousel.current.style.transition = 'none'
-                carousel.current.style.transform = `translateX(0)`
-                // mandamos al final el item que acabamos de mover
-                carousel.current.appendChild(firstItem)
-            }, 300)
-        }
+  const sliderData = useSelector((state) => state.slidesReducer.slides.data);
+
+  const nextSlide = () => {
+    // Me aseguro que se ejecute solo cuando el carrusel tenga contenido
+    if (carousel.current.children.length > 0) {
+      // Primer item carrusel
+      const firstItem = carousel.current.children[0];
+      // Animacion de transicion
+      carousel.current.style.transition = "300ms ease-out all";
+      // obtengo cuanto mide cada item, asi se cuanto desplazarlo
+      const slideWidth = firstItem.offsetWidth;
+      // Movemos el slide actual para mostrar el nuevo
+      carousel.current.style.transform = `translateX(-${slideWidth}px)`;
+
+      // el slide viejo lo tenemos que poner al final de la fila, asi se comporta como slide infinito
+      // pero antes de ponerlo al final, hay que esperar que termine la animacion
+      setTimeout(() => {
+        carousel.current.style.transition = "none";
+        carousel.current.style.transform = `translateX(0)`;
+        // mandamos al final el item que acabamos de mover
+        carousel.current.appendChild(firstItem);
+      }, 300);
     }
+  };
 
-    const prevSlide = () => {
-        if (carousel.current.children.length > 0) {
-            const lastItemIndex = carousel.current.children.length - 1
-            const lastItem = carousel.current.children[lastItemIndex]
-            carousel.current.insertBefore(lastItem, carousel.current.firstChild)
+  const prevSlide = () => {
+    if (carousel.current.children.length > 0) {
+      const lastItemIndex = carousel.current.children.length - 1;
+      const lastItem = carousel.current.children[lastItemIndex];
+      carousel.current.insertBefore(lastItem, carousel.current.firstChild);
 
-            carousel.current.style.transition = 'none'
-            const slideWidth = carousel.current.children[0].offsetWidth
-            carousel.current.style.transform = `translateX(-${slideWidth}px)`
+      carousel.current.style.transition = "none";
+      const slideWidth = carousel.current.children[0].offsetWidth;
+      carousel.current.style.transform = `translateX(-${slideWidth}px)`;
 
-            setTimeout(() => {
-                carousel.current.style.transition = '300ms ease-out all'
-                carousel.current.style.transform = `translateX(0)`
-            }, 30)
-        }
+      setTimeout(() => {
+        carousel.current.style.transition = "300ms ease-out all";
+        carousel.current.style.transform = `translateX(0)`;
+      }, 30);
     }
+  };
 
+  // Para hacer que el slider cambie automaticamente cada 5 segundos
+  useEffect(() => {
+    // Esto hace que el slider cambie cada 5 segundos
+    // esto puede genera que un usuario no alcance a leer la informacion del slide
+    // o que cuando le de click al siguiente slide, este cambie 2 veces
+    // seguidas porque justo pasaron 5 segundo y se cambia automaticamente
+    intervalCarousel.current = setInterval(() => {
+      nextSlide();
+    }, 5000);
+    // Cuando el mouse este encima del slider eliminamos el intervalo
+    // para que este no cambiara automaticamente
+    carousel.current.addEventListener("mouseenter", () => {
+      clearInterval(intervalCarousel.current);
+    });
+    // Cuando el mouse deje estar sobre el slider, reestablecemos el intervalo
+    carousel.current.addEventListener("mouseleave", () => {
+      intervalCarousel.current = setInterval(() => {
+        nextSlide();
+      }, 5000);
+    });
+  }, []);
 
-    // Para hacer que el slider cambie automaticamente cada 5 segundos
-    useEffect(() => {
-        // Esto hace que el slider cambie cada 5 segundos
-        // esto puede genera que un usuario no alcance a leer la informacion del slide
-        // o que cuando le de click al siguiente slide, este cambie 2 veces
-        // seguidas porque justo pasaron 5 segundo y se cambia automaticamente
-        intervalCarousel.current = setInterval(() => {
-            nextSlide()
-        }, 5000)
-        // Cuando el mouse este encima del slider eliminamos el intervalo 
-        // para que este no cambiara automaticamente 
-        carousel.current.addEventListener('mouseenter', () => {
-            clearInterval(intervalCarousel.current)
-        })
-        // Cuando el mouse deje estar sobre el slider, reestablecemos el intervalo
-        carousel.current.addEventListener('mouseleave', () => {
-            intervalCarousel.current = setInterval(() => {
-                nextSlide()
-            }, 5000)
-        })
-    }, [])
-
-    const getSlides = async () => {
-        try {
-            const response = await getSlidesData()
-            setSliderData(response.data.data)
-        } catch (error) {
-            return error
-        }
-    }
-    useEffect(() => {
-        getSlides()
-    }, [])
-
-
-    return (
-        <div className='slider'>
-            <div className='slider__container' ref={carousel}>
-                {sliderData.map((slide) => (
-                    <div className='slider__item' key={slide.id}>
-                        <img className='slider__img' src={slide.image} alt={slide.name} />
-                        <div className='slider__text'>
-                            <p className='slider__text--title'>{slide.name}</p>
-                            <p className='slider__text--description'>{slide.description}</p>
-                        </div>
-                    </div>
-                ))}
+  return (
+    <div className="slider">
+      <div className="slider__container" ref={carousel}>
+        {sliderData.map((slide) => (
+          <div className="slider__item" key={slide.id}>
+            <img className="slider__img" src={slide.image} alt={slide.name} />
+            <div className="slider__text">
+              <p className="slider__text--title">{slide.name}</p>
+              <p className="slider__text--description">{slide.description}</p>
             </div>
-            <div className='slider__controllers'>
-                <span className='material-icons slider__arrow-button slider__arrow-button--left' onClick={prevSlide}>
-                    chevron_left
-                </span>
-                <span className='material-icons slider__arrow-button slider__arrow-button--right' onClick={nextSlide}>
-                    chevron_right
-                </span>
-            </div>
-        </div>
-    )
+          </div>
+        ))}
+      </div>
+      <div className="slider__controllers">
+        <span
+          className="material-icons slider__arrow-button slider__arrow-button--left"
+          onClick={prevSlide}
+        >
+          chevron_left
+        </span>
+        <span
+          className="material-icons slider__arrow-button slider__arrow-button--right"
+          onClick={nextSlide}
+        >
+          chevron_right
+        </span>
+      </div>
+    </div>
+  );
 };
 
 export default SliderHome;

--- a/src/Pages/Slides/SlideList.js
+++ b/src/Pages/Slides/SlideList.js
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { getSlides } from "../../Redux/reducers/slidesSlice";
+import { useSelector, useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -8,8 +10,6 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import "./SlideList.css";
-import { getSlides } from "../../Redux/reducers/slidesSlice";
-import { useSelector, useDispatch } from "react-redux";
 
 const SlideList = () => {
   const dispatch = useDispatch();

--- a/src/Pages/Slides/SlideList.js
+++ b/src/Pages/Slides/SlideList.js
@@ -8,45 +8,17 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import "./SlideList.css";
+import { getSlides } from "../../Redux/reducers/slidesSlice";
+import { useSelector, useDispatch } from "react-redux";
 
 const SlideList = () => {
-  const slideList = {
-    data: [
-      {
-        id: 1,
-        name: "Ignacio",
-        image: "http://ongapi.alkemy.org/storage/j8Uo4skOTP.jpeg",
-        order: 5454,
-      },
-      {
-        id: 2,
-        name: "Roman",
-        image: "http://ongapi.alkemy.org/storage/rEZJhWbxCx.jpeg",
-        order: 8989,
-      },
-      {
-        id: 3,
-        name: "Título de prueba",
-        image: "http://ongapi.alkemy.org/storage/tRMcq6w2JV.jpeg",
-        order: 1,
-      },
-      {
-        id: 4,
-        name: "myslide",
-        image: "http://ongapi.alkemy.org/storage/ae5LYQeuId.png",
-        order: 4555,
-      },
-    ],
-  };
-  const [slides, setSlides] = useState([]);
-
-  const getSlidesData = () => {
-    setSlides(slideList.data);
-  };
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    getSlidesData();
+    dispatch(getSlides());
   }, []);
+
+  const slides = useSelector((state) => state.slidesReducer.slides.data);
 
   const rows = slides;
 
@@ -64,31 +36,26 @@ const SlideList = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {rows &&
-              rows.map(({ id, name, image, order }) => (
-                <TableRow key={id}>
-                  <TableCell align="center">{name}</TableCell>
-                  <TableCell align="center">
-                    <img src={image} alt="" className="imageTable" />
-                  </TableCell>
-                  <TableCell align="center">{order}</TableCell>
-                  <TableCell>
-                    <button>
-                      <Link to={`/backoffice/slides/edicion/${id}`}>
-                        Editar
-                      </Link>
-                    </button>
-                  </TableCell>
-                  <TableCell align="center">
-                    <button>
-                      {/*TODO: Crear ruta*/}
-                      <Link to={`/backoffice/slides/delete/${id}`}>
-                        Eliminar
-                      </Link>
-                    </button>
-                  </TableCell>
-                </TableRow>
-              ))}
+            {rows.map(({ id, name, image, order }) => (
+              <TableRow key={id}>
+                <TableCell align="center">{name}</TableCell>
+                <TableCell align="center">
+                  <img src={image} alt="" className="imageTable" />
+                </TableCell>
+                <TableCell align="center">{order}</TableCell>
+                <TableCell>
+                  <button>
+                    <Link to={`/backoffice/slides/edicion/${id}`}>Editar</Link>
+                  </button>
+                </TableCell>
+                <TableCell align="center">
+                  <button>
+                    {/*TODO: Crear ruta*/}
+                    <Link to={`/backoffice/slides/delete/${id}`}>Eliminar</Link>
+                  </button>
+                </TableCell>
+              </TableRow>
+            ))}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/Redux/reducers/slidesSlice.js
+++ b/src/Redux/reducers/slidesSlice.js
@@ -2,7 +2,9 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { getSlidesData } from "../../Services/slidesApiService";
 
 export const getSlides = createAsyncThunk("slides/getSlides", () => {
-  getSlidesData().then((res) => res.data.data);
+  return getSlidesData().then((res) => {
+    return res.data.data;
+  });
 });
 
 export const slidesSlice = createSlice({
@@ -10,25 +12,27 @@ export const slidesSlice = createSlice({
   initialState: {
     slides: {
       status: "idle",
-      data: {},
+      data: [],
       error: {},
     },
   },
   reducers: {},
   extraReducers: {
-    [getSlides.fulfilled.type]: (state, action) => {
+    [getSlides.fulfilled]: (state, action) => {
       state.slides = {
         status: "idle",
         data: action.payload,
         error: {},
       };
     },
-    [getSlides.rejected.type]: (state, action) => {
+    [getSlides.rejected]: (state, action) => {
       state.slides = {
         status: "idle",
-        data: {},
+        data: [],
         error: action.payload,
       };
     },
   },
 });
+
+export default slidesSlice.reducer;

--- a/src/Redux/reducers/slidesSlice.js
+++ b/src/Redux/reducers/slidesSlice.js
@@ -1,0 +1,34 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { getSlidesData } from "../../Services/slidesApiService";
+
+export const getSlides = createAsyncThunk("slides/getSlides", () => {
+  getSlidesData().then((res) => res.data.data);
+});
+
+export const slidesSlice = createSlice({
+  name: "slides",
+  initialState: {
+    slides: {
+      status: "idle",
+      data: {},
+      error: {},
+    },
+  },
+  reducers: {},
+  extraReducers: {
+    [getSlides.fulfilled.type]: (state, action) => {
+      state.slides = {
+        status: "idle",
+        data: action.payload,
+        error: {},
+      };
+    },
+    [getSlides.rejected.type]: (state, action) => {
+      state.slides = {
+        status: "idle",
+        data: {},
+        error: action.payload,
+      };
+    },
+  },
+});

--- a/src/Redux/store/store.js
+++ b/src/Redux/store/store.js
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
-import {authReducer} from "../reducers/authReducer";
-import newsReducer from "../reducers/newsSlice"
+import { authReducer } from "../reducers/authReducer";
+import newsReducer from "../reducers/newsSlice";
+import slidesReducer from "../reducers/slidesSlice";
 
 export default configureStore({
   reducer: {
     authReducer: authReducer,
-    newsReducer: newsReducer
+    newsReducer: newsReducer,
+    slidesReducer,
   },
 });


### PR DESCRIPTION
Utilizando redux-toolkit, desarrollar un reducer para gestionar el estado de los Slides en el BackOffice. El mismo deberá tener una acción para renderizar el listado de los Slides en BackOffice.

La lógica existente de peticiones a la API deberá moverse a thunks asíncronos dentro del reducer. 

Utilizar el método createAsyncThunk de Redux Toolkit para la creación de thunks: 
https://redux.js.org/tutorials/essentials/part-5-async-logic#writing-async-thunks

Summary

- Creacion de reducer para los Slides
- Uso de redux en los componentes de Slide

Evidence

- Carousel 
![home](https://user-images.githubusercontent.com/65054792/152664640-96c7871d-da7d-4467-abbd-8a63e6687331.png)

- Listado de Slides en el backoffice
![slidelist](https://user-images.githubusercontent.com/65054792/152664643-d90ab10d-8181-4cc1-a2e7-72744cf0d819.png)

