### PR TITLE
Ot127 101/feat/mostrar errores peticiones home

### DIFF
--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { sweetAlertError } from "./sweetAlertServices";
 
 const config = {
   headers: {
@@ -10,24 +11,26 @@ const Get = async (url, id) => {
   if (id) {
     const response = await axios
       .get(`${url}/${id}`, config)
-      .catch((err) => err.message);
+      .catch(sweetAlertError("No se pudo cargar todo el contenido"));
 
     return response;
   } else {
-    const response = await axios.get(url, config).catch((err) => err.message);
+    const response = await axios.get(url, config).catch((error) => {
+      sweetAlertError("No se pudo cargar todo el contenido");
+    });
 
     return response;
   }
 };
 
 export { Get };
-	
+
 export const Post = async (url, data) => {
-	//README:
-	//Ingresar la url del endpoint a utilizar
-	//Pasar objeto como argum para enviarlo en el body
-	await axios
-	.post(url, data, config)
-	.then(res => res)
-	.catch(err => err.message)
-}
+  //README:
+  //Ingresar la url del endpoint a utilizar
+  //Pasar objeto como argum para enviarlo en el body
+  await axios
+    .post(url, data, config)
+    .then((res) => res)
+    .catch((err) => err.message);
+};

--- a/src/Services/slidesApiService.js
+++ b/src/Services/slidesApiService.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { sweetAlertError } from "./sweetAlertServices";
 
 const url = process.env.REACT_APP_ENDPOINT_SLIDES;
 
@@ -12,12 +13,10 @@ const toDataURL = (blob) =>
   });
 
 export const getSlidesData = async () => {
-  try {
-    const response = await axios.get(url);
-    return response;
-  } catch (error) {
-    return error;
-  }
+  const response = await axios.get(url).catch((error) => {
+    sweetAlertError("No se pudo cargar todo el contenido");
+  });
+  return response;
 };
 
 export const getSearch = async (search) => {


### PR DESCRIPTION
Resumen

- Mostrar errores cuando las peticiones en el Home no se realicen correctamente
- Implementado el servicio de alerta de errores

Evidencia

Error servicio slides:

![error servicio slides](https://user-images.githubusercontent.com/70604758/155226736-42ed9ee8-a9b6-4a42-86fb-5d320ea9b3ba.png)

Error servicio novedades:

![error servicio novedades](https://user-images.githubusercontent.com/70604758/155226822-0b8fb7a8-fe9b-4d77-b55a-e1a0ced9b29c.png)

