### PR TITLE
OT127/Fix/Home-backoffice

### DIFF
--- a/src/Components/Sidebar/Sidebar.js
+++ b/src/Components/Sidebar/Sidebar.js
@@ -11,7 +11,6 @@ const Sidebar = () => {
 
   const backofficeRoutes = [
     { name: "Home", router: "/backoffice/home", icon: "home" },
-    { name: "Backoffice", router: "/backoffice", icon: "settings" },
     { name: "Users", router: "/backoffice/users", icon: "person" },
     { name: "Slides", router: "/backoffice/slides", icon: "auto_awesome_motion" },
     { name: "Members", router: "/backoffice/members", icon: "face" },


### PR DESCRIPTION
Estimada, Flavia 

Este PR es para quitar del Sidebar el acceso a la ruta de backoffice que no tiene contendido se decidió que el usuario llego directo al componente /backoffice/home